### PR TITLE
Fix macos dependecies

### DIFF
--- a/documentation/obtain-storm/dependencies.md
+++ b/documentation/obtain-storm/dependencies.md
@@ -57,12 +57,12 @@ For troubleshooting building on ARM-based <i class="fa fa-apple" aria-hidden="tr
 
 - Required:
 ``` console
-$ brew install automake cmake boost gmp glpk hwloc
+$ brew install automake boost cln ginac glpk hwloc
 ```
 
 - Recommended:
 ``` console
-$ brew install automake cmake boost gmp glpk hwloc z3 xerces-c
+$ brew install automake boost cln ginac glpk hwloc z3 xerces-c
 ```
 
 #### Intel-based Systems


### PR DESCRIPTION
The dependecies for building from source on mac are no longer correct. I added cln and ginac and removed cmake. This comes from the storm mac test ci.